### PR TITLE
Add a WorldEvent.load handler that re-parses features

### DIFF
--- a/src/main/java/cofh/cofhworld/init/WorldHandler.java
+++ b/src/main/java/cofh/cofhworld/init/WorldHandler.java
@@ -24,6 +24,7 @@ import net.minecraftforge.event.terraingen.OreGenEvent.GenerateMinable.EventType
 import net.minecraftforge.event.terraingen.PopulateChunkEvent;
 import net.minecraftforge.event.terraingen.SaplingGrowTreeEvent;
 import net.minecraftforge.event.world.ChunkDataEvent;
+import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.common.IWorldGenerator;
 import net.minecraftforge.fml.common.ModAPIManager;
 import net.minecraftforge.fml.common.ModContainer;
@@ -130,6 +131,24 @@ public class WorldHandler implements IWorldGenerator {
 	}
 
 	/* EVENT HANDLERS */
+	@SubscribeEvent
+ 	public void handleWorldLoadEvent(WorldEvent.Load event) {
+		if (WorldProps.dynamicConfigReload) {
+			CoFHWorld.log.info("Reloading feature config...");
+
+			// Reset all features so that config will reload properly
+			features.clear();
+			featureNames.clear();
+
+			// Parse all the generation files into features
+			try {
+				FeatureParser.parseGenerationFiles();
+			} catch (Throwable t) {
+				t.printStackTrace();
+			}
+		}
+	}
+
 	@SubscribeEvent
 	public void handlePopulateChunkEvent(PopulateChunkEvent.Pre event) {
 

--- a/src/main/java/cofh/cofhworld/init/WorldProps.java
+++ b/src/main/java/cofh/cofhworld/init/WorldProps.java
@@ -41,6 +41,9 @@ public class WorldProps {
 		comment = "This adjusts the % chance that a tree will grow as normal when it is meant to. Reducing this value will mean that trees take longer to grow, on average.";
 		chanceTreeGrowth = CoFHWorld.config.getInt("TreeGrowthChance", category, chanceTreeGrowth, 1, 100, comment);
 
+		comment = "If TRUE, configuration will be reloaded when the world is loaded.";
+		dynamicConfigReload = CoFHWorld.config.getBoolean("DynamicConfigReload", category, dynamicConfigReload, comment);
+
 		category = "World.Bedrock";
 
 		comment = "If TRUE, the bedrock layer will be flattened.";
@@ -128,6 +131,8 @@ public class WorldProps {
 
 	public static boolean disableStandardGeneration = false;
 	public static boolean enableRetroactiveGeneration = false;
+
+	public static boolean dynamicConfigReload = false;
 
 	public static boolean enableFlatBedrock = false;
 	public static boolean enableRetroactiveFlatBedrock = false;


### PR DESCRIPTION
This PR enables (via configuration option) the ability to reload feature config every time a world is loaded. While this is clearly not something you'd want enabled by default, it should allow users to more quickly iterate on different feature configurations by creating a new world.