### PR TITLE
Redux of world commands

### DIFF
--- a/src/main/java/cofh/cofhworld/CoFHWorld.java
+++ b/src/main/java/cofh/cofhworld/CoFHWorld.java
@@ -1,14 +1,17 @@
 package cofh.cofhworld;
 
+import cofh.cofhworld.command.CommandCoFHWorld;
 import cofh.cofhworld.init.FeatureParser;
 import cofh.cofhworld.init.WorldHandler;
 import cofh.cofhworld.init.WorldProps;
+import net.minecraft.world.World;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.Mod.Instance;
 import net.minecraftforge.fml.common.event.FMLLoadCompleteEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -57,14 +60,15 @@ public class CoFHWorld {
 	@EventHandler
 	public void loadComplete(FMLLoadCompleteEvent event) {
 
-		try {
-			FeatureParser.parseGenerationFiles();
-		} catch (Throwable t) {
-			t.printStackTrace();
-		}
+		WorldHandler.reloadConfig();
 		config.save();
 
 		log.info(MOD_NAME + ": Load Complete.");
 	}
 
+	@Mod.EventHandler
+	public void onServerStarted(FMLServerStartingEvent event)
+	{
+		event.registerServerCommand(new CommandCoFHWorld());
+	}
 }

--- a/src/main/java/cofh/cofhworld/command/CommandCoFHWorld.java
+++ b/src/main/java/cofh/cofhworld/command/CommandCoFHWorld.java
@@ -34,15 +34,15 @@ public class CommandCoFHWorld extends CommandTreeBase {
 
         @Override
         public String getUsage(ICommandSender sender) {
-            return "reload.usage";
+            return "cofhworld.reload.usage";
         }
 
         @Override
         public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
             if (WorldHandler.reloadConfig()) {
-                notifyCommandListener(sender, this, "reload.successful");
+                notifyCommandListener(sender, this, "cofhworld.reload.successful");
             } else {
-                notifyCommandListener(sender, this, "reload.failed");
+                notifyCommandListener(sender, this, "cofhworld.reload.failed");
             }
         }
     }
@@ -57,7 +57,7 @@ public class CommandCoFHWorld extends CommandTreeBase {
 
         @Override
         public String getUsage(ICommandSender sender) {
-            return "list.usage";
+            return "cofhworld.list.usage";
         }
 
         @Override
@@ -67,7 +67,7 @@ public class CommandCoFHWorld extends CommandTreeBase {
             for (IFeatureGenerator feature: WorldHandler.getFeatures()) {
                 b.append("* " + feature.getFeatureName() + "\n");
             }
-            notifyCommandListener(sender, this, "list", b.toString());
+            notifyCommandListener(sender, this, "cofhworld.list", b.toString());
         }
     }
 }

--- a/src/main/java/cofh/cofhworld/command/CommandCoFHWorld.java
+++ b/src/main/java/cofh/cofhworld/command/CommandCoFHWorld.java
@@ -1,0 +1,73 @@
+package cofh.cofhworld.command;
+
+import cofh.cofhworld.feature.IFeatureGenerator;
+import cofh.cofhworld.init.WorldHandler;
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.server.command.CommandTreeBase;
+
+public class CommandCoFHWorld extends CommandTreeBase {
+
+    @Override
+    public String getName() {
+        return "cofhworld";
+    }
+
+    @Override
+    public String getUsage(ICommandSender sender) {
+        return "cofhworld.usage";
+    }
+
+    public CommandCoFHWorld() {
+        addSubcommand(new CommandReload());
+        addSubcommand(new CommandList());
+    }
+
+    // Command to reload all feature definitions
+    public static class CommandReload extends CommandBase {
+        @Override
+        public String getName() {
+            return "reload";
+        }
+
+        @Override
+        public String getUsage(ICommandSender sender) {
+            return "reload.usage";
+        }
+
+        @Override
+        public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
+            if (WorldHandler.reloadConfig()) {
+                notifyCommandListener(sender, this, "reload.successful");
+            } else {
+                notifyCommandListener(sender, this, "reload.failed");
+            }
+        }
+    }
+
+    // Command to list all feature definitions
+    public static class CommandList extends CommandBase {
+
+        @Override
+        public String getName() {
+            return "list";
+        }
+
+        @Override
+        public String getUsage(ICommandSender sender) {
+            return "list.usage";
+        }
+
+        @Override
+        public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
+            StringBuilder b = new StringBuilder();
+            b.append("\n");
+            for (IFeatureGenerator feature: WorldHandler.getFeatures()) {
+                b.append("* " + feature.getFeatureName() + "\n");
+            }
+            notifyCommandListener(sender, this, "list", b.toString());
+        }
+    }
+}

--- a/src/main/java/cofh/cofhworld/init/WorldHandler.java
+++ b/src/main/java/cofh/cofhworld/init/WorldHandler.java
@@ -98,6 +98,21 @@ public class WorldHandler implements IWorldGenerator {
 
 	}
 
+	public static boolean reloadConfig() {
+		// Reset all features so that config will reload properly
+		features.clear();
+		featureNames.clear();
+
+		// Parse all the generation files into features
+		try {
+			FeatureParser.parseGenerationFiles();
+			return true;
+		} catch (Throwable t) {
+			t.printStackTrace();
+			return false;
+		}
+	}
+
 	public static boolean registerFeature(IFeatureGenerator feature) {
 
 		String featureName = feature.getFeatureName();
@@ -129,6 +144,19 @@ public class WorldHandler implements IWorldGenerator {
 		return true;
 	}
 
+	public static IFeatureGenerator findFeature(String name) {
+		for (IFeatureGenerator feature : features) {
+				if (feature.getFeatureName().equals(name)) {
+					return feature;
+				}
+			}
+			return null;
+		}
+	
+	public static List<IFeatureGenerator> getFeatures() {
+		return features;
+	}
+	
 	/* EVENT HANDLING */
 	@SubscribeEvent
 	public void handlePopulateChunkEvent(PopulateChunkEvent.Pre event) {

--- a/src/main/resources/assets/cofhworld/lang/en_US.lang
+++ b/src/main/resources/assets/cofhworld/lang/en_US.lang
@@ -1,6 +1,6 @@
 
-reload.usage=Reloads CoFHWorld configuration
-reload.successful=Configuration reloaded.
-reload.failed=Failed to reload config; check your logs.
-list.usage=Lists all CoFHWorld features
-list=Available CoFHWorld features: %s
+cofhworld.reload.usage=Reloads CoFHWorld configuration
+cofhworld.reload.successful=Configuration reloaded.
+cofhworld.reload.failed=Failed to reload config; check your logs.
+cofhworld.list.usage=Lists all CoFHWorld features
+cofhworld.list=Available CoFHWorld features: %s

--- a/src/main/resources/assets/cofhworld/lang/en_US.lang
+++ b/src/main/resources/assets/cofhworld/lang/en_US.lang
@@ -1,0 +1,6 @@
+
+reload.usage=Reloads CoFHWorld configuration
+reload.successful=Configuration reloaded.
+reload.failed=Failed to reload config; check your logs.
+list.usage=Lists all CoFHWorld features
+list=Available CoFHWorld features: %s


### PR DESCRIPTION
Re-patch against 1.12 branch.

Introduces basic structure for adding runtime control over CoFHWorld generation. Supported commands are:

> /cofh feature - prints list of available commands
> /cofh feature list - prints list of available features which CoFHWorld is generating
> /cofh feature reload - forces a reload of the CoFHWorld configs

I'm working on the ability to dynamically generate a feature on demand in front of the user, but it will have to be a separate PR as it's a significant set of changes. :/