### PR TITLE
Set acceptableRemoteVersions to "*" in @Mod annotation

### DIFF
--- a/src/main/java/cofh/cofhworld/CoFHWorld.java
+++ b/src/main/java/cofh/cofhworld/CoFHWorld.java
@@ -15,7 +15,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 
-@Mod (modid = CoFHWorld.MOD_ID, name = CoFHWorld.MOD_NAME, version = CoFHWorld.VERSION, dependencies = CoFHWorld.DEPENDENCIES, updateJSON = CoFHWorld.UPDATE_URL, certificateFingerprint = "8a6abf2cb9e141b866580d369ba6548732eff25f")
+@Mod (modid = CoFHWorld.MOD_ID, name = CoFHWorld.MOD_NAME, version = CoFHWorld.VERSION, dependencies = CoFHWorld.DEPENDENCIES, updateJSON = CoFHWorld.UPDATE_URL, acceptableRemoteVersions = "*", certificateFingerprint = "8a6abf2cb9e141b866580d369ba6548732eff25f")
 public class CoFHWorld {
 
 	public static final String MOD_ID = "cofhworld";


### PR DESCRIPTION
This allows vanilla clients to servers with this mod installed.
I've tested this with a Forge server, a vanilla client and the JSON files [here](https://github.com/TheRandomLabs/LightChocolate/tree/master/overrides/config/cofh/world).