### PR TITLE
Add replace blocks function

### DIFF
--- a/src/main/java/cofh/cofhworld/init/WorldProps.java
+++ b/src/main/java/cofh/cofhworld/init/WorldProps.java
@@ -69,6 +69,7 @@ public class WorldProps {
 		FeatureParser.registerTemplate("cave", new DistParserCave());
 		FeatureParser.registerTemplate("sequential", new DistParserSequential());
 		FeatureParser.registerTemplate("custom", new DistParserCustom());
+		FeatureParser.registerTemplate("replace", new DistParserReplace());
 
 		log.info("Registering default World Generators...");
 		FeatureParser.registerGenerator(null, new GenParserCluster(false));

--- a/src/main/java/cofh/cofhworld/parser/distribution/DistParserReplace.java
+++ b/src/main/java/cofh/cofhworld/parser/distribution/DistParserReplace.java
@@ -1,0 +1,40 @@
+package cofh.cofhworld.parser.distribution;
+
+import cofh.cofhworld.parser.IDistributionParser;
+import cofh.cofhworld.parser.variables.BlockData;
+import cofh.cofhworld.util.random.WeightedBlock;
+import cofh.cofhworld.world.IConfigurableFeatureGenerator;
+import cofh.cofhworld.world.distribution.DistributionReplace;
+import com.typesafe.config.Config;
+import org.apache.logging.log4j.Logger;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+
+public class DistParserReplace implements IDistributionParser {
+
+    private final String[] FIELDS = new String[] { "block", "replacement" };
+
+    @Override
+    public String[] getRequiredFields() {
+        return FIELDS;
+    }
+
+    @Nonnull
+    @Override
+    public IConfigurableFeatureGenerator getFeature(String featureName, Config genObject, boolean retrogen, Logger log) throws InvalidDistributionException {
+
+        List<WeightedBlock> blockstates = new ArrayList<>();
+        if (!BlockData.parseBlockList(genObject.root().get("block"), blockstates, true)) {
+            throw new InvalidDistributionException("`block` not valid", genObject.origin());
+        }
+
+        List<WeightedBlock> replacement = new ArrayList<>();
+        if (!BlockData.parseBlockList(genObject.root().get("replacement"), replacement, false)) {
+            throw new InvalidDistributionException("`replacement` not valid", genObject.origin());
+        }
+
+        return new DistributionReplace(featureName, retrogen, blockstates, replacement);
+    }
+}

--- a/src/main/java/cofh/cofhworld/world/distribution/DistributionReplace.java
+++ b/src/main/java/cofh/cofhworld/world/distribution/DistributionReplace.java
@@ -1,0 +1,37 @@
+package cofh.cofhworld.world.distribution;
+
+import cofh.cofhworld.util.random.WeightedBlock;
+import cofh.cofhworld.world.generator.WorldGen;
+import net.minecraft.world.World;
+
+import java.util.List;
+import java.util.Random;
+
+public class DistributionReplace extends Distribution {
+
+    private final WeightedBlock[] blockstates;
+    private final List<WeightedBlock> replacement;
+
+    public DistributionReplace(String featureName, boolean retrogen, List<WeightedBlock> blockstates, List<WeightedBlock> replacement) {
+        super(featureName, retrogen);
+
+        this.blockstates = blockstates.toArray(new WeightedBlock[blockstates.size()]);
+        this.replacement = replacement;
+    }
+
+    @Override
+    public boolean generateFeature(Random random, int blockX, int blockZ, World world) {
+        boolean generated = false;
+        for (int x = blockX; x < blockX + 16; x++)
+        for (int z = blockZ; z < blockZ + 16; z++) {
+            if (!canGenerateInBiome(world, x, z, random)) {
+                continue;
+            }
+
+            for (int y = 0; y < world.getHeight(); y++) {
+                generated |= WorldGen.generateBlock(world, random, x, y, z, blockstates, replacement);
+            }
+        }
+        return generated;
+    }
+}


### PR DESCRIPTION
Primarily useful for retro-gen wiping the output of other mod generators which you have since decided to replace with cofh-world.

Sample usage:
```
"distribution": "replace",
"block": [
	{
		"name": "projectred-exploration:ore",
		"properties": { "type": "ruby_ore" }
	},
	{
		"name": "projectred-exploration:ore",
		"properties": { "type": "sapphire_ore" }
	},
	{
		"name": "projectred-exploration:ore",
		"properties": { "type": "peridot_ore" }
	}
],
"replacement": "minecraft:stone",
"retrogen": "true",
"biome": "all",
"dimension": {
	"restriction": "blacklist",
	"value": [
		-1,
		1
	]
}
```

Possible concerns:
The use of "block" is actually blocks to replace rather than blocks to generate here, perhaps make more consistent with "material" and "block" rather than "block" and "replacement"

Performance, there's currently no way to specify /only/ on retrogen which is the primary use-case here. 